### PR TITLE
leading lepton pT and EE noisy jets removal for 2017, trigger matched muon requirement for Run 2

### DIFF
--- a/tests/hmm/analysis_hmumu.py
+++ b/tests/hmm/analysis_hmumu.py
@@ -384,12 +384,14 @@ def main(args, datasets):
                 },
 
             "muon_pt": 20,
-            "muon_pt_leading": {"2016": 26.0, "2017": 26.0, "2018": 26.0},
+            "muon_pt_leading": {"2016": 26.0, "2017": 29.0, "2018": 26.0},
             "muon_eta": 2.4,
             "muon_iso": 0.25,
             "muon_id": {"2016": "medium", "2017": "medium", "2018": "medium"},
             "muon_trigger_match_dr": 0.1,
-            
+            "muon_iso_trigger_matched": 0.15,
+            "muon_id_trigger_matched": {"2016": "tight", "2017": "tight", "2018": "tight"},
+ 
             "do_rochester_corrections": True, 
             "do_lepton_sf": True,
             
@@ -401,6 +403,8 @@ def main(args, datasets):
             "jet_eta": 4.7,
             "jet_id": "tight",
             "jet_puid": "loose",
+            "jet_veto_eta": [2.65, 3.139],
+            "jet_veto_raw_pt": 50.0,  
             "jet_btag": {"2016": 0.6321, "2017": 0.4941, "2018": 0.4184},
             "do_factorized_jec": args.do_factorized_jec,
 


### PR DESCRIPTION
There changes:

(1) leading lepton pT > 29 GeV (previously in the code 26 GeV) for the year of 2017
(2) require the trigger matched muon to pass tight ID and tight isolation (<0.15) criteria because the trigger SF is derived for these muons. This is for all three years
(3) add EE noise jets removal for 2017. The jets following the following criteria should be rejected:

2.65<|eta|<3.139

and 

raw jet pT < 50.0 GeV

Implementation in HmmAna: https://github.com/irenedutta23/HmmAna/blob/44a20bd759d81c7e78c98d3b8d48546a6c329169/HmmAnalyzer.cc#L257
