### PR TITLE
add L1Prefire Weight to 2016 and 2017 MC and correct PU unc and 2016 trig SF

### DIFF
--- a/tests/hmm/hmumu_utils.py
+++ b/tests/hmm/hmumu_utils.py
@@ -157,7 +157,10 @@ def analyze_data(
 
     hists["hist__dimuon__npvs"] = fill_with_weights(
         scalars["PV_npvsGood"], weights, ret_mu["selected_events"], NUMPY_LIB.linspace(0,100,101, dtype=NUMPY_LIB.float32))
-    
+   
+    #Apply weights
+    compute_event_weights(weights, scalars, genweight_scalefactor, pu_corrections, is_mc, dataset_era)
+ 
     #Just a check to verify that there are exactly 2 muons per event
     if doverify:
         z = ha.sum_in_offsets(
@@ -577,10 +580,26 @@ def compute_event_weights(weights, scalars, genweight_scalefactor, pu_correction
             print("pu_weights_up", pu_weights_up.mean(), pu_weights_up.std())
             print("pu_weights_down", pu_weights_down.mean(), pu_weights_down.std())
 
-        weights["puWeight_off"] = weights["nominal"] 
-        weights["puWeight__up"] = weights["nominal"] * pu_weights_up
-        weights["puWeight__down"] = weights["nominal"] * pu_weights_down
-        weights["nominal"] = weights["nominal"] * pu_weights
+        if NUMPY_LIB.logical_or(dataset_era == "2016",dataset_era == "2017"):
+            if debug:
+                print("mean L1PreFiringWeight_Nom=", scalars["L1PreFiringWeight_Nom"].mean())
+                print("mean L1PreFiringWeight_Up=", scalars["L1PreFiringWeight_Up"].mean())
+                print("mean L1PreFiringWeight_Dn=", scalars["L1PreFiringWeight_Dn"].mean())
+            weights["puWeight_off"] = weights["nominal"] * scalars["L1PreFiringWeight_Nom"]
+            weights["puWeight__up"] = weights["nominal"] * scalars["L1PreFiringWeight_Nom"] * pu_weights_up
+            weights["puWeight__down"] = weights["nominal"] * scalars["L1PreFiringWeight_Nom"] * pu_weights_down
+            weights["L1PreFiringWeight_off"] = weights["nominal"] * pu_weights
+            weights["L1PreFiringWeight__up"] = weights["nominal"] * pu_weights * scalars["L1PreFiringWeight_Up"]
+            weights["L1PreFiringWeight__down"] = weights["nominal"] * pu_weights * scalars["L1PreFiringWeight_Dn"]
+            weights["nominal"] = weights["nominal"] * pu_weights * scalars["L1PreFiringWeight_Nom"]
+        else:
+            weights["puWeight_off"] = weights["nominal"]
+            weights["puWeight__up"] = weights["nominal"] * pu_weights_up
+            weights["puWeight__down"] = weights["nominal"] * pu_weights_down
+            weights["nominal"] = weights["nominal"] * pu_weights
+            weights["L1PreFiringWeight_off"] = weights["nominal"]
+            weights["L1PreFiringWeight__up"] = weights["nominal"]
+            weights["L1PreFiringWeight__down"] = weights["nominal"]
 
     for wn in weights.keys():
         print("w", wn, weights[wn].mean())
@@ -1752,7 +1771,10 @@ def compute_lepton_sf(leading_muon, subleading_muon, lepsf_iso, lepsf_id, lepsf_
 
         sf_iso = lepsf_iso.compute(pdgid, mu["pt"], mu["eta"])
         sf_id = lepsf_id.compute(pdgid, mu["pt"], mu["eta"])
-        sf_trig = lepsf_trig.compute(pdgid, mu["pt"], mu["eta"])
+        if dataset_era == "2016":
+            sf_trig = lepsf_trig.compute(pdgid, mu["pt"], NUMPY_LIB.abs(mu["eta"]))
+        else:
+            sf_trig = lepsf_trig.compute(pdgid, mu["pt"], mu["eta"])
         if debug:
             print("sf_iso: ", sf_iso.mean(), "+-", sf_iso.std())
             print("sf_id: ", sf_id.mean(), "+-", sf_id.std())
@@ -2053,6 +2075,12 @@ def create_datastructure(is_mc, dataset_era):
             ("Generator_weight", "float32"),
             ("genWeight", "float32")
         ]
+        if NUMPY_LIB.logical_or(dataset_era == "2016",dataset_era == "2017"):
+            datastructures["EventVariables"] += [
+                ("L1PreFiringWeight_Nom", "float32"),
+                ("L1PreFiringWeight_Dn", "float32"),
+                ("L1PreFiringWeight_Up", "float32")
+            ]
         datastructures["Muon"] += [
             ("Muon_genPartIdx", "int32"),
         ]

--- a/tests/hmm/pars.py
+++ b/tests/hmm/pars.py
@@ -128,9 +128,9 @@ jec_unc = ['AbsoluteFlavMap', 'AbsoluteMPFBias', 'AbsoluteSample', 'AbsoluteScal
 #, 'SubTotalAbsolute', 'SubTotalMC', 'SubTotalPileUp',
 #    'SubTotalPt', 'SubTotalRelative', 'SubTotalScale', 'TimePtEta', 'Total', 'TotalNoFlavor',
 #    'TotalNoFlavorNoTime', 'TotalNoTime']
- 
-uncertainties = jec_unc + ["puWeight"]
-shape_systematics = jec_unc + ["jer", "puWeight"]
+
+uncertainties = jec_unc + ["puWeight", "L1PreFiringWeight"]
+shape_systematics = jec_unc + ["jer", "puWeight", "L1PreFiringWeight"]
 common_scale_uncertainties = {
     "lumi": 1.025,
 }


### PR DESCRIPTION
(1) add L1Prefire Weight to 2016 and 2017 MC and the uncertainties, including in datacard as well.

(2) correct PU uncertainty calculation.

(3) correct 2016 trig SF for muons with negative eta values. The histogram provided by the POG for 2016 is based on |eta| and pt