### PR TITLE
Add FSR recovery

### DIFF
--- a/tests/hmm/analysis_hmumu.py
+++ b/tests/hmm/analysis_hmumu.py
@@ -51,6 +51,7 @@ def parse_args():
     parser.add_argument('--eras', action='append', help='Data eras to process', type=str, required=False)
     parser.add_argument('--pinned', action='store_true', help='Use CUDA pinned memory')
     parser.add_argument('--do-sync', action='store_true', help='run only synchronization datasets')
+    parser.add_argument('--do-fsr', action='store_true', help='add FSR recovery')
     parser.add_argument('--do-factorized-jec', action='store_true', help='Enables factorized JEC, disables most validation plots')
     parser.add_argument('--do-profile', action='store_true', help='Profile the code with yappi')
     parser.add_argument('--disable-tensorflow', action='store_true', help='Disable loading and evaluating the tensorflow model')

--- a/tests/hmm/hmumu_utils.py
+++ b/tests/hmm/hmumu_utils.py
@@ -210,8 +210,9 @@ def analyze_data(
         fsr1_kin = (leading_muon["pt_FSR"], leading_muon["eta_FSR"], leading_muon["phi_FSR"], 0)
         mu2_kin = (subleading_muon["pt"], subleading_muon["eta"], subleading_muon["phi"], subleading_muon["mass"])
         fsr2_kin = (subleading_muon["pt_FSR"], subleading_muon["eta_FSR"], subleading_muon["phi_FSR"], 0)
-        leading_muon["pt"], leading_muon["eta"], leading_muon["phi"] = sum_four_vectors([mu1_kin, fsr1_kin])
-        subleading_muon["pt"], subleading_muon["eta"], subleading_muon["phi"] = sum_four_vectors([mu2_kin, fsr2_kin])
+        size = len(leading_muon["pt"])
+        leading_muon["pt"], leading_muon["eta"], leading_muon["phi"] = sum_four_vectors([mu1_kin, fsr1_kin], size)
+        subleading_muon["pt"], subleading_muon["eta"], subleading_muon["phi"] = sum_four_vectors([mu2_kin, fsr2_kin], size)
 
     if doverify:
         assert(NUMPY_LIB.all(leading_muon["pt"][leading_muon["pt"]>0] > parameters["muon_pt_leading"][dataset_era]))
@@ -1409,7 +1410,15 @@ def compute_jet_raw_pt(jets):
     raw_pt = jets.pt * (1.0 - jets.rawFactor)
     return raw_pt
 
-def sum_four_vectors(objects):
+def sum_four_vectors(objects, size):
+    px = NUMPY_LIB.zeros(size, dtype=np.float32)
+    py = NUMPY_LIB.zeros(size, dtype=np.float32)
+    pz = NUMPY_LIB.zeros(size, dtype=np.float32)
+    e = NUMPY_LIB.zeros(size, dtype=np.float32)
+    px_total = NUMPY_LIB.zeros(size, dtype=np.float32)
+    py_total = NUMPY_LIB.zeros(size, dtype=np.float32)
+    pz_total = NUMPY_LIB.zeros(size, dtype=np.float32)
+    e_total = NUMPY_LIB.zeros(size, dtype=np.float32)
     for pt, eta, phi, mass in objects:
         px = pt * np.cos(phi)
         py = pt * np.sin(phi)

--- a/tests/hmm/hmumu_utils.py
+++ b/tests/hmm/hmumu_utils.py
@@ -213,7 +213,7 @@ def analyze_data(
         leading_muon["pt"], leading_muon["eta"], leading_muon["phi"] = sum_four_vectors([mu1_kin, fsr1_kin])
         subleading_muon["pt"], subleading_muon["eta"], subleading_muon["phi"] = sum_four_vectors([mu2_kin, fsr2_kin])
 
-   if doverify:
+    if doverify:
         assert(NUMPY_LIB.all(leading_muon["pt"][leading_muon["pt"]>0] > parameters["muon_pt_leading"][dataset_era]))
         assert(NUMPY_LIB.all(subleading_muon["pt"][subleading_muon["pt"]>0] > parameters["muon_pt"]))
 


### PR DESCRIPTION
Hi,

I've started implementing FSR recovery basing on the structure of private nanoAOD produced by Pisa group [0]. In this implementation, variables [Muon_pt_FSR, Muon_eta_FSR, Muon_phi_FSR] form a four-vector (with zero mass) that has to be added to the four-vector of a muon.

This PR is not ready for merging, as I haven't tested it yet and some parts are implemented quite naively (hmumu_utils.py L1412-1426), but you are welcome to review it and make suggestions while I continue working on it.

[0] [https://cmsweb.cern.ch/das/request?view=list&limit=50&instance=prod%2Fphys03&input=%2F*%2Farizzi*FSR*V2*%2FUSER](https://cmsweb.cern.ch/das/request?view=list&limit=50&instance=prod%2Fphys03&input=%2F*%2Farizzi*FSR*V2*%2FUSER)