### PR TITLE
Enable 2017 puid weights

### DIFF
--- a/tests/hmm/hmumu_utils.py
+++ b/tests/hmm/hmumu_utils.py
@@ -1645,10 +1645,6 @@ def get_selected_jets(
 def get_puid_weights(jets, passed_puid, evaluator, era, wp, jet_pt_min, jet_pt_max, use_cuda):
     nev = jets.numevents()
 
-    # PU ID weights haven't been validated for 2017 yet
-    if era=="2017":
-        return NUMPY_LIB.ones(nev, dtype=NUMPY_LIB.float32)
-
     wp_dict = {"loose": "L", "medium": "M", "tight": "T"}
     jets_pu_eff, jets_pu_sf = jet_puid_evaluate(evaluator, era, wp_dict[wp], NUMPY_LIB.asnumpy(jets.pt), NUMPY_LIB.asnumpy(jets.eta))
     jet_pt_mask = ((NUMPY_LIB.asnumpy(jets.pt)>jet_pt_min) & (NUMPY_LIB.asnumpy(jets.pt)<jet_pt_max))


### PR DESCRIPTION
2017 Data/MC plots for validation:
w/o PUID weights: https://www.dropbox.com/sh/lmf8yst4ue2u5wo/AAAaOqnv9vXr1AwaVqIX9Ejda?dl=0
with PUID weights: https://www.dropbox.com/sh/hdkqkfmn6aba25a/AAD5TuNIDPwi2EiXp8eVRZx1a?dl=0
