### PR TITLE
keep/drop branches in the skim and merge code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - conda update -q conda
   - conda info -a
   - conda config --add channels conda-forge
-  - conda create -n myenv
+  - conda create -n myenv python=3.7
   - conda activate myenv
   - conda install awkward cffi cloudpickle lz4 numba numpy psutil python-xxhash pyyaml requests root scipy six tbb tqdm uproot xxhash boost matplotlib
   - pip install tensorflow keras

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,13 +31,13 @@ install:
 
 
 script:
-    - PYTHONPATH=coffea:hepaccelerate:. python tests/hmm/hmumu_utils.py
-    - wget https://jpata.web.cern.ch/jpata/hmm/test_files/myNanoProdMc2016_NANO.root -O data/myNanoProdMc2016_NANO.root
-    - PYTHONPATH=coffea:hepaccelerate:. python tests/hmm/test_hmumu_utils.py --debug
-    - wget https://jpata.web.cern.ch/jpata/hmm/test_files/nano_2016_data.root -O data/nano_2016_data.root
+    - PYTHONPATH=coffea:hepaccelerate:. python tests/hmm/hmumu_utils.py || travis_terminate 1
+    - wget https://jpata.web.cern.ch/jpata/hmm/test_files/myNanoProdMc2016_NANO.root -O data/myNanoProdMc2016_NANO.root || travis_terminate 1
+    - PYTHONPATH=coffea:hepaccelerate:. python tests/hmm/test_hmumu_utils.py --debug || travis_terminate 1
+    - wget https://jpata.web.cern.ch/jpata/hmm/test_files/nano_2016_data.root -O data/nano_2016_data.root || travis_terminate 1
     - echo data/myNanoProdMc2016_NANO.root > skim.txt
-    - python tests/hmm/skim_and_recompress.py -i ./skim.txt -o ./data/myNanoProdMc2016_NANO_skim.root -s "(HLT_IsoMu24 || HLT_IsoTkMu24) && nMuon>=2" -t ./ -b batch/branches.txt
+    - python tests/hmm/skim_and_recompress.py -i ./skim.txt -o ./data/myNanoProdMc2016_NANO_skim.root -s "(HLT_IsoMu24 || HLT_IsoTkMu24) && nMuon>=2" -t ./ -b batch/branches.txt || travis_terminate 1
     - echo data/nano_2016_data.root > skim.txt
-    - python tests/hmm/skim_and_recompress.py -i ./skim.txt -o ./data/nano_2016_data_skim.root -s "(HLT_IsoMu24 || HLT_IsoTkMu24) && nMuon>=2" -t ./ -b batch/branches.txt
-    - wget https://jpata.web.cern.ch/jpata/hmm/test_files/CBCAE1AB-4AFD-D840-BE00-9E5ABD2E4A20.root -O data/CBCAE1AB-4AFD-D840-BE00-9E5ABD2E4A20.root
-    - PYTHONPATH=coffea:hepaccelerate:. python tests/hmm/test_analysis_full.py --debug
+    - python tests/hmm/skim_and_recompress.py -i ./skim.txt -o ./data/nano_2016_data_skim.root -s "(HLT_IsoMu24 || HLT_IsoTkMu24) && nMuon>=2" -t ./ -b batch/branches.txt || travis_terminate 1
+    - wget https://jpata.web.cern.ch/jpata/hmm/test_files/CBCAE1AB-4AFD-D840-BE00-9E5ABD2E4A20.root -O data/CBCAE1AB-4AFD-D840-BE00-9E5ABD2E4A20.root || travis_terminate 1
+    - PYTHONPATH=coffea:hepaccelerate:. python tests/hmm/test_analysis_full.py --debug || travis_terminate 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,8 @@ script:
     - PYTHONPATH=coffea:hepaccelerate:. python tests/hmm/test_hmumu_utils.py --debug
     - wget https://jpata.web.cern.ch/jpata/hmm/test_files/nano_2016_data.root -O data/nano_2016_data.root
     - echo data/myNanoProdMc2016_NANO.root > skim.txt
-    - python tests/hmm/skim_and_recompress.py -i ./skim.txt -o ./data/myNanoProdMc2016_NANO_skim.root -s "(HLT_IsoMu24 || HLT_IsoTkMu24) && nMuon>=2" -t ./
+    - python tests/hmm/skim_and_recompress.py -i ./skim.txt -o ./data/myNanoProdMc2016_NANO_skim.root -s "(HLT_IsoMu24 || HLT_IsoTkMu24) && nMuon>=2" -t ./ -b batch/branches.txt
     - echo data/nano_2016_data.root > skim.txt
-    - python tests/hmm/skim_and_recompress.py -i ./skim.txt -o ./data/nano_2016_data_skim.root -s "(HLT_IsoMu24 || HLT_IsoTkMu24) && nMuon>=2" -t ./
+    - python tests/hmm/skim_and_recompress.py -i ./skim.txt -o ./data/nano_2016_data_skim.root -s "(HLT_IsoMu24 || HLT_IsoTkMu24) && nMuon>=2" -t ./ -b batch/branches.txt
     - wget https://jpata.web.cern.ch/jpata/hmm/test_files/CBCAE1AB-4AFD-D840-BE00-9E5ABD2E4A20.root -O data/CBCAE1AB-4AFD-D840-BE00-9E5ABD2E4A20.root
     - PYTHONPATH=coffea:hepaccelerate:. python tests/hmm/test_analysis_full.py --debug

--- a/batch/branches.txt
+++ b/batch/branches.txt
@@ -1,0 +1,5 @@
+drop FatJet*
+drop GenVisTau*
+drop Tau*
+drop IsoTrack*
+drop SubJet*

--- a/batch/hmm_cache.sh
+++ b/batch/hmm_cache.sh
@@ -11,7 +11,7 @@ mv skim_merge/*.txt ./
 ls -al
 
 #Run the code
-python2 $SUBMIT_DIR/tests/hmm/skim_and_recompress.py -i $1 -o $2 -t ./ -s "$3"
+python2 $SUBMIT_DIR/tests/hmm/skim_and_recompress.py --infiles $1 --out $2 --temppath ./ --skim "$3" --branches $SUBMIT_DIR/batch/branches.txt 
 
 #This didn't use to be necessary??
 rm -Rf *.txt *.tgz

--- a/tests/hmm/prepare_merge_argfile.py
+++ b/tests/hmm/prepare_merge_argfile.py
@@ -36,9 +36,6 @@ def parse_args():
     args = parser.parse_args()
     return args
 
-shellscript_template = """
-"""
-
 if __name__ == "__main__":
     args = parse_args()
     datasets = yaml.load(open(args.input), Loader=yaml.FullLoader)
@@ -46,10 +43,10 @@ if __name__ == "__main__":
     argfile = open("args_merge.txt", "w")
     for ds in datasets["datasets"]:
         print(ds) 
-        dataset_name = ds["name"] 
-        dataset_era = ds["era"] 
+        dataset_name = ds["name"]
+        dataset_era = ds["era"]
         path = ds["files_nano_in"]
-        skim_cut = ds["skim_cut"] 
+        skim_cut = ds["skim_cut"]
  
         filenames = match_filenames(args.datapath + path, ds["files_merged"])
         nfiles = 0
@@ -61,5 +58,6 @@ if __name__ == "__main__":
                 print(fn, file=fi)
             
             outfile = args.outpath + ds["files_merged"].replace("*.root", "{0}.root".format(ich))
+            #output command
             print(infiles_name, outfile, skim_cut.replace(" ", ""), file=argfile)
         assert(nfiles == len(filenames))

--- a/tests/hmm/skim_and_recompress.py
+++ b/tests/hmm/skim_and_recompress.py
@@ -6,33 +6,39 @@ import os
 import tempfile
 import argparse
 
+branch_status_flag = {"keep": True, "drop": False}
+ 
 #Given one NanoAOD file, open the Events tree, select events that pass the skim_cut, drop unneeded branches
 #and recompress with LZ4 (~30% larger, but much faster to load)
-def skim_recompress_one_file(outfile, infile, skim_cut):
+def skim_recompress_one_file(outfile, infile, skim_cut, drop_branches):
     print("skim_one_file", infile, outfile)
     tf = ROOT.TFile(infile)
-
     of = ROOT.TFile(outfile, "RECREATE")
 
-    #use LZ4 for fast decompression
+    #change the output to use LZ4 for fast decompression
     of.SetCompressionAlgorithm(4)
     of.SetCompressionLevel(9)
 
-    if skim_cut == "1":
-        t1 = tf.Get("Events").CloneTree()
-    else:
-        tt = tf.Get("Events")
-        tt.SetBranchStatus("FatJet*", False)
-        tt.SetBranchStatus("GenVisTau*", False)
-        tt.SetBranchStatus("Tau*", False)
-        tt.SetBranchStatus("IsoTrack*", False)
-        tt.SetBranchStatus("SubJet*", False)
-        t1 = tt.CopyTree(skim_cut)
+    tt = tf.Get("Events")
+    for cmd, bname in keep_drop_commands:
+        tt.SetBranchStatus(bname, branch_status_flag[cmd])
+
+    t1 = tt.CopyTree(skim_cut)
+    nev = t1.GetEntries()
+    print(nev)
     t3 = tf.Get("LuminosityBlocks").CloneTree()
     t4 = tf.Get("Runs").CloneTree()
 
     of.Write()
     of.Close()
+    return nev
+
+def get_file_entries(fn):
+    nev = 0
+    of = ROOT.TFile.Open(fn)
+    tt = of.Get("Events")
+    nev = tt.GetEntries()
+    return nev
 
 def hadd(outfile, infiles):
     """ Uses hadd to merge ROOT files.
@@ -48,6 +54,11 @@ def hadd(outfile, infiles):
         Exception if call to merge failed.
     """
     print("hadd {0} {1}".format(outfile, " ".join(infiles)))
+
+    #Check the input TTree entries 
+    nev = sum([get_file_entries(inf) for inf in infiles])
+
+    #Run the actual merging 
     d = os.path.dirname(outfile)
     try:
         os.makedirs(d)
@@ -58,19 +69,27 @@ def hadd(outfile, infiles):
     ret = subprocess.call(cmd)
     if ret != 0:
         raise Exception("could not merge {0}".format(outfile))
+  
+    #Check the output TTree entries 
+    nev2 = get_file_entries(outfile) 
+    if nev != nev2:
+        raise Exception("Merged TTree did not have the same number of events as the input TTrees: {}!={}. ".format(nev, nev2) + 
+            "Please check the output of 'hadd' for warnings!")  
+
     return outfile
 
 def skim_and_merge(args):
-    outfile, infiles, skim_str, temppath = args
+    outfile, infiles, skim_str, temppath, keep_drop_commands = args
 
     if os.path.isfile(outfile):
         print("skipping {0}".format(outfile))
         return
 
     tmp_files = []
+    nev = 0
     for infile in infiles:
         _, new_fn = tempfile.mkstemp(suffix=".root", dir=temppath)
-        skim_recompress_one_file(new_fn, infile, skim_str)
+        nev += skim_recompress_one_file(new_fn, infile, skim_str, keep_drop_commands)
         tmp_files += [new_fn]
     hadd(outfile, tmp_files)
     
@@ -78,27 +97,56 @@ def skim_and_merge(args):
     for fn in tmp_files:
         os.remove(fn)
 
-def merge_no_recompression(args):
-    outfile, infiles, skim_str, temppath = args
-    if os.path.isfile(outfile):
-        return
-    hadd(outfile, infiles)
+def get_branches(fn, treename):
+    tf = ROOT.TFile(fn)
+    tt = tf.Get(treename)
+    brs = [b.GetName() for b in tt.GetListOfBranches()]
+    return set(brs)
+
+def get_common_branches(filenames):
+    sets = []
+    for infile in infiles:
+        brs = get_branches(infile, "Events")
+        sets.append(brs)
+    
+    common_branches = set.intersection(*sets)
+    return sorted(list(common_branches))
 
 def parse_args():
-    parser = argparse.ArgumentParser(description='Skim, slim, recompress and merge nanoaod files')
+    parser = argparse.ArgumentParser(description='Skim, slim, merge and recompress NANOAOD files')
     parser.add_argument('--infiles', '-i', action='store', help='filename with list of input files', required=True)
     parser.add_argument('--out', '-o', action='store', help='output file', required=True)
     parser.add_argument('--skim', '-s', action='store', help='skim cut', default="1")
     parser.add_argument('--temppath', '-t', action='store', help='temporary file path', required=True)
-    parser.add_argument('--lz4', action='store_true', help='recompress with lz4')
+    parser.add_argument('--branches', '-b', action='store', help='Filename with keep/drop commands for branches')
     args = parser.parse_args()
     return args
+
+def parse_keep_drop(fn):
+    fi = open(fn)
+    cmds = []
+    for line in fi.readlines():
+        cmd = line.strip().split()
+        if not (len(cmd) == 2 and (cmd[0] in ["keep", "drop"])):
+            raise Exception("Invalid keep/drop command: {}".format(line))
+        cmds += [cmd]
+    return cmds
  
 if __name__ == "__main__":
     print(sys.argv)
     args = parse_args()
     infiles = map(lambda x: x.strip(), open(args.infiles).readlines())
-    if args.lz4 or args.skim != "1":
-        skim_and_merge((args.out, infiles, args.skim, args.temppath))
-    else:
-        merge_no_recompression((args.out, infiles, args.skim, args.temppath))
+
+    keep_drop_commands = []
+
+    #Find the common branches among the files
+    common_branches = get_common_branches(infiles)
+    keep_drop_commands = [("drop", "*")] + [("keep", b) for b in common_branches]
+
+    #Additional keep/drop commands
+    if args.branches:
+        keep_drop_commands += parse_keep_drop(args.branches)
+
+    for cmd in keep_drop_commands:
+        print(cmd)
+    skim_and_merge((args.out, infiles, args.skim, args.temppath, keep_drop_commands))

--- a/tests/hmm/skim_and_recompress.py
+++ b/tests/hmm/skim_and_recompress.py
@@ -35,8 +35,8 @@ def skim_recompress_one_file(outfile, infile, skim_cut, drop_branches):
 
 def get_file_entries(fn):
     nev = 0
-    of = ROOT.TFile.Open(fn)
-    tt = of.Get("Events")
+    tf = ROOT.TFile.Open(fn)
+    tt = tf.Get("Events")
     nev = tt.GetEntries()
     return nev
 
@@ -136,6 +136,8 @@ if __name__ == "__main__":
     print(sys.argv)
     args = parse_args()
     infiles = map(lambda x: x.strip(), open(args.infiles).readlines())
+    if len(infiles) == 0:
+        raise Exception("No input files specified, please check {}".format(args.infiles))
 
     keep_drop_commands = []
 

--- a/tests/hmm/skim_and_recompress.py
+++ b/tests/hmm/skim_and_recompress.py
@@ -135,7 +135,7 @@ def parse_keep_drop(fn):
 if __name__ == "__main__":
     print(sys.argv)
     args = parse_args()
-    infiles = map(lambda x: x.strip(), open(args.infiles).readlines())
+    infiles = list(map(lambda x: x.strip(), open(args.infiles).readlines()))
     if len(infiles) == 0:
         raise Exception("No input files specified, please check {}".format(args.infiles))
 


### PR DESCRIPTION
- When merging files using `skim_and_recompress.py`, keep only the branches that are common to all files.
- Enable specifying additional keep/drops from a text file, by default common for all datasets and stored in `batch/branches.txt`.
- The skim & merge code will throw an exception if the number of events before and after the merge is different.
- fix automatic test (python 3.8 -> 3.7)