### PR TITLE
Fix random segfault with libiomp5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,9 @@ install:
   - conda config --add channels conda-forge
   - conda create -n myenv python=3.7
   - conda activate myenv
-  - conda install awkward cffi cloudpickle lz4 numba numpy psutil python-xxhash pyyaml requests root scipy six tbb tqdm uproot xxhash boost matplotlib
-  - pip install tensorflow keras
+  - conda install --channel "intel" -y tbb numba numpy scipy tensorflow-gpu==1.14.0 
+  - conda install awkward cffi cloudpickle lz4 psutil python-xxhash pyyaml requests root six tbb tqdm uproot xxhash boost matplotlib
+  - pip install -U keras
   - pip install coffea
   - cd tests/hmm
   - make

--- a/tests/hmm/Makefile
+++ b/tests/hmm/Makefile
@@ -1,6 +1,9 @@
 all: libhmm.so
 
-CXX      = g++ -fPIC -fopenmp -O3
+# We need to be careful to link against the intel version of OpenMP to prevent segfaults
+# https://stackoverflow.com/questions/25986091/telling-gcc-to-not-link-libgomp-so-it-links-libiomp5-instead
+CXX      = g++ -fPIC -O3
+LINK     = g++ -fPIC -L/usr/local/anaconda3/lib -liomp5 -lmkl_intel_thread
 
 CXXFLAGS= $(shell root-config --cflags)
 LIBS    = $(shell root-config --libs)
@@ -14,7 +17,7 @@ OBJECTS = $(SOURCES:.cc=.o)
 	$(CXX) $(CXXFLAGS) -c -o $@ $< 
 
 libhmm.so: $(OBJECTS)
-	$(CXX) $(LIBS) -shared -o $@ $^
+	$(LINK) $(LIBS) -shared -o $@ $^
 
 # Specifying the object files as intermediates deletes them automatically after the build process.
 .INTERMEDIATE:  $(OBJECTS) tmva

--- a/tests/hmm/hmumu_lib.py
+++ b/tests/hmm/hmumu_lib.py
@@ -74,6 +74,10 @@ class RochesterCorrections:
 
     def compute_kScaleDT(self, pts, etas, phis, charges):
         out = numpy_lib.zeros_like(pts)
+        nev = len(pts)
+        assert(len(etas) == nev)
+        assert(len(phis) == nev)
+        assert(len(charges) == nev)
         self.libhmm.roccor_kScaleDT(self.c_class,
             self.libhmm.cast_as("float *", out), len(out), #output
             self.libhmm.cast_as("int *", charges),
@@ -86,6 +90,13 @@ class RochesterCorrections:
 
     def compute_kSpreadMC_or_kSmearMC(self, pts, etas, phis, charges, genpts, tracklayers, rnds):
         out = numpy_lib.zeros_like(pts)
+        nev = len(pts)
+        assert(len(etas) == nev)
+        assert(len(phis) == nev)
+        assert(len(charges) == nev)
+        assert(len(genpts) == nev)
+        assert(len(tracklayers) == nev)
+        assert(len(rnds) == nev)
         self.libhmm.roccor_kSpreadMC_or_kSmearMC(self.c_class,
             self.libhmm.cast_as("float *", out), len(out), #output
             self.libhmm.cast_as("int *", charges),
@@ -171,6 +182,8 @@ class NNLOPSReweighting:
 
     def compute(self, genNjets, genHiggs_pt, igen):
         out_nnlow = numpy_lib.ones_like(genNjets, dtype=numpy_lib.float32)
+        nev = len(genNjets)
+        assert(len(genHiggs_pt) == nev)
         self.libhmm.NNLOPSReweighting_eval(
             self.c_class,
             igen,
@@ -195,6 +208,10 @@ class hRelResolution:
 
     def compute(self, mu1_pt, mu1_eta, mu2_pt, mu2_eta):
         out_hres = numpy_lib.ones_like(mu1_pt, dtype=numpy_lib.float32)
+        nev = len(mu1_pt)
+        assert(len(mu1_eta) == nev)
+        assert(len(mu2_pt) == nev)
+        assert(len(mu2_eta) == nev)
         self.libhmm.hRelResolution_eval(
             self.c_class,
             self.libhmm.cast_as("float *", out_hres),
@@ -228,6 +245,14 @@ class MiscVariables:
 
     def csangles(self, pt1, eta1, phi1, mass1, pt2, eta2, phi2, mass2, charges):
         nev = len(pt1)
+        assert(len(eta1) == nev)
+        assert(len(phi1) == nev)
+        assert(len(mass1) == nev)
+        assert(len(pt2) == nev)
+        assert(len(eta2) == nev)
+        assert(len(phi2) == nev)
+        assert(len(mass2) == nev)
+        assert(len(charges) == nev)
         out_theta = numpy_lib.zeros(nev, dtype=numpy_lib.float32)
         out_phi = numpy_lib.zeros(nev, dtype=numpy_lib.float32)
 
@@ -249,6 +274,14 @@ class MiscVariables:
 
     def csanglesPisa(self, pt1, eta1, phi1, mass1, pt2, eta2, phi2, mass2, charges):
         nev = len(pt1)
+        assert(len(eta1) == nev)
+        assert(len(phi1) == nev)
+        assert(len(mass1) == nev)
+        assert(len(pt2) == nev)
+        assert(len(eta2) == nev)
+        assert(len(phi2) == nev)
+        assert(len(mass2) == nev)
+        assert(len(charges) == nev)
         out_theta = numpy_lib.zeros(nev, dtype=numpy_lib.float32)
         out_phi = numpy_lib.zeros(nev, dtype=numpy_lib.float32)
 
@@ -271,6 +304,10 @@ class MiscVariables:
     def ptcorrgeofit(self, d0_BS, pt_Roch, eta, charge, year):
         nev = len(pt_Roch)
         out_pt = numpy_lib.zeros(nev, dtype=numpy_lib.float32)
+        assert(len(d0_BS) == nev)
+        assert(len(eta) == nev)
+        assert(len(charge) == nev)
+        assert(len(year) == nev)
         self.libhmm.ptcorrgeofit_eval(
             self.libhmm.cast_as("float *", out_pt),
             nev,

--- a/tests/hmm/hmumu_utils.py
+++ b/tests/hmm/hmumu_utils.py
@@ -2218,7 +2218,7 @@ def do_geofit_corrections(
     miscvariables,
     muons,
     dataset_era):
-    years = int(dataset_era)*NUMPY_LIB.ones(len(muons.pt), dtype=NUMPY_LIB.int8)
+    years = int(dataset_era)*NUMPY_LIB.ones(len(muons.pt), dtype=NUMPY_LIB.int32)
     muon_pt_corr = miscvariables.ptcorrgeofit(
         NUMPY_LIB.asnumpy(muons.dxybs),
         NUMPY_LIB.asnumpy(muons.pt),


### PR DESCRIPTION
Random, non-reproducible segfault with
```
OMP: Warning #190: Forking a process while a parallel region is active is potentially unsafe.
OMP: Warning #190: Forking a process while a parallel region is active is potentially unsafe.
 Generating stack trace...
 Generating stack trace...
OMP: Warning #190: Forking a process while a parallel region is active is potentially unsafe.
OMP: Warning #190: Forking a process while a parallel region is active is potentially unsafe.
OMP: Warning #190: Forking a process while a parallel region is active is potentially unsafe.
OMP: Warning #190: Forking a process while a parallel region is active is potentially unsafe.
OMP: Warning #190: Forking a process while a parallel region is active is potentially unsafe.
 0x00002abfe9c74ed3 in __kmp_invoke_microtask + 0x93 from /usr/local/anaconda3/lib/python3.7/site-packages/mkl/../../../libiomp5.so
 0x00002abfe9c37726 in <unknown> from /usr/local/anaconda3/lib/python3.7/site-packages/mkl/../../../libiomp5.so
 0x00002abfe9c3671c in <unknown> from /usr/local/anaconda3/lib/python3.7/site-packages/mkl/../../../libiomp5.so
 0x00002abfe9c7530b in <unknown> from /usr/local/anaconda3/lib/python3.7/site-packages/mkl/../../../libiomp5.so
 0x00002abfe7e4de65 in <unknown> from /lib64/libpthread.so.0
 0x00002abfe816088d in clone + 0x6d from /lib64/libc.so.6
sh: which: command not found
/usr/bin/addr2line: '0x000055e18096e8fb': No such file
OMP: Warning #190: Forking a process while a parallel region is active is potentially unsafe.
sh: which: command not found
/usr/bin/addr2line: '0x000055e1809d26e8': No such file
OMP: Warning #190: Forking a process while a parallel region is active is potentially unsafe.
sh: which: command not found
/usr/bin/addr2line: '0x000055e180965ccb': No such file
```
is caused by an incompatible use of both GNU OpenMP and Intel OpenMP, see e.g. here: https://github.com/intel/mkl-dnn/issues/100

This should fix it. Making sure it's propagated also to the automatic test.