### PR TITLE
Fix travis test failure due to new ROOT version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ install:
   - conda activate myenv
   - conda install --channel "intel" -y tbb numba numpy scipy tensorflow-gpu==1.14.0 
   - conda install awkward cffi cloudpickle lz4 psutil python-xxhash pyyaml requests root six tbb tqdm uproot xxhash boost matplotlib
-  - conda install -c conda-forge zstd
+  - conda remove zstd
+  - conda install zstd
   - pip install -U keras
   - pip install coffea
   - cd tests/hmm

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,8 @@ install:
   - conda create -n myenv python=3.7
   - conda activate myenv
   - conda install --channel "intel" -y tbb numba numpy scipy tensorflow-gpu==1.14.0 
-  - conda install awkward cffi cloudpickle lz4 psutil python-xxhash pyyaml requests root six tbb tqdm uproot xxhash boost matplotlib
-  - conda remove zstd
-  - conda install zstd
+  - conda install awkward cffi cloudpickle lz4 psutil python-xxhash pyyaml requests six tbb tqdm uproot xxhash boost matplotlib
+  - conda install root=6.18.04
   - pip install -U keras
   - pip install coffea
   - cd tests/hmm

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
   - conda activate myenv
   - conda install --channel "intel" -y tbb numba numpy scipy tensorflow-gpu==1.14.0 
   - conda install awkward cffi cloudpickle lz4 psutil python-xxhash pyyaml requests root six tbb tqdm uproot xxhash boost matplotlib
+  - conda install -c conda-forge zstd
   - pip install -U keras
   - pip install coffea
   - cd tests/hmm


### PR DESCRIPTION
The root got upgraded in conda a few days ago, which caused a crash due to libzstd:
```
cannot load library '/home/travis/build/jpata/hepaccelerate-cms/tests/hmm/libhmm.so': libzstd.so.1.3.7: cannot open shared object file: No such file or directory
```
I did not investigate why this happens, but rather just pinned ROOT to version 6.18.04.